### PR TITLE
Fixed issue #2 when linking MIOTY lib 

### DIFF
--- a/Template/Makefile
+++ b/Template/Makefile
@@ -16,7 +16,8 @@ endif
 include $(CONTIKI)/Makefile.include
 
 
-LDFLAGS += $(LIB_PATH)/$(LIBRARY)
+# LDFLAGS += $(LIB_PATH)/$(LIBRARY)
+TARGET_LIBFILES += $(LIB_PATH)/$(LIBRARY)
 
 CFLAGS += -Iincludes
 


### PR DESCRIPTION
# Verification 
- Extracted the library using `ar` and checked for the symbol using `nm`. The symbol was found.
- Passed a flag to generate a memory layout of the compiled program (`.map`) to verify if the library was linked.
The `.map file` showed no MIOTY-related symbols, confirming a linking issue.

# Changes
- Linked library as a `TARGET_LIBFILES` instead of `LDFLAGS` - [ref](https://stackoverflow.com/questions/32579489/how-to-add-a-source-file-on-contikis-makefile)